### PR TITLE
Fix multiple definition linker error of 'dtostrf' for ArduinoCore-mbed

### DIFF
--- a/src/dtostrf.c
+++ b/src/dtostrf.c
@@ -17,6 +17,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#if !defined(ARDUINO_ARCH_MBED)
+
 #include <stdio.h>
 
 char *dtostrf (double val, signed char width, unsigned char prec, char *sout)
@@ -28,3 +30,5 @@ char *dtostrf (double val, signed char width, unsigned char prec, char *sout)
   sprintf(sout, fmt, val);
   return sout;
 }
+
+#endif /* !defined(ARDUINO_ARCH_MBED) */


### PR DESCRIPTION
This fixes #7.