### PR TITLE
Signal that this library only works for mbed and samd boards.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library for providing convenient macros for printf-style debugg
 paragraph=
 category=Other
 url=https://github.com/107-systems/107-Arduino-Debug
-architectures=*
+architectures=samd,mbed
 includes=ArduinoDebug.hpp


### PR DESCRIPTION
This fixes #11.